### PR TITLE
chore: override *.as2 to ActionScript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.as2 linguist-language=ActionScript

--- a/button.as2
+++ b/button.as2
@@ -1,0 +1,1 @@
+on(release){_root.num = random(35)+1;}

--- a/button.txt
+++ b/button.txt
@@ -1,3 +1,0 @@
-//ActionScript 2.0
-//AngelScript가 아닙니다.
-on(release){_root.num = random(35)+1;}


### PR DESCRIPTION
`.gitattributes` 파일 설정을 통해서 GitHub Linguist가 `*.as2` 파일을 액션스크립트로 인식하게 합니다.